### PR TITLE
"Wijzig" naar "Bewaar" veranderd

### DIFF
--- a/Grocery.App/Views/ChangeColorView.xaml
+++ b/Grocery.App/Views/ChangeColorView.xaml
@@ -13,6 +13,6 @@
 
     <VerticalStackLayout>
         <Editor Text="{Binding GroceryList.Color}" x:Name="newColor"/>
-        <Button Text="wijzig kleur" Command="{Binding ChangeColorCommand}" CommandParameter="{Binding Source={x:Reference newColor}, Path=Text}" />
+        <Button Text="Bewaar kleur" Command="{Binding ChangeColorCommand}" CommandParameter="{Binding Source={x:Reference newColor}, Path=Text}" />
     </VerticalStackLayout>
 </ContentPage>


### PR DESCRIPTION
UC04 - De labeltekst van de knop is aangepast van "Wijzig" naar "Bewaar" zodat de gebruiker beter begrijpt dat de actie wijzigingen opslaat in plaats van bewerken start.
